### PR TITLE
chore[SIW-1040]: Make Android crypto key available only with unlocked device

### DIFF
--- a/android/src/main/java/com/pagopa/ioreactnativeintegrity/IoReactNativeIntegrityModule.kt
+++ b/android/src/main/java/com/pagopa/ioreactnativeintegrity/IoReactNativeIntegrityModule.kt
@@ -204,6 +204,7 @@ class IoReactNativeIntegrityModule(reactContext: ReactApplicationContext) :
       .setDigests(KeyProperties.DIGEST_SHA256).setKeySize(256).setAttestationChallenge(challenge)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && hasStrongBox) {
       builder.setIsStrongBoxBacked(true)
+      builder.setUnlockedDeviceRequired(true)
     }
     val keyPairGenerator = KeyPairGenerator.getInstance(
       KeyProperties.KEY_ALGORITHM_EC, KEYSTORE_PROVIDER


### PR DESCRIPTION
### Short description
This PR sets the cryptographic key accessibility on Android. 
We want the key to be usable only when the device has been unlocked.

#### List of Changes
- Use the method `setUnlockedDeviceRequired` when generating a key for the attestation. This option is only available for API level 28, hence the guard.

#### How Has This Been Tested?
Test the example app by generating a new attestation.
