### PR TITLE
refactor: [SIW-1176] Change decoded assertion format on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A (Key Attestation)[https://developer.android.com/privacy-and-security/security-
 During key attestation, a key pair is generated along with its certificate chain hich can be used to verify the properties of that key pair.
 If the device supports hardware-level key attestation, the root certificate of the chain is signed using an attestation root key protected by the device's hardware-backed keystore.
 
-
 ### `isPlayServicesAvailable`
 
 Returns a boolean value indicating whether the Play Services are available on the device or not.
@@ -64,6 +63,7 @@ try {
 
 Requests an integrity token which is then attached to the request to be protected.
 It must be called AFTER `prepareIntegrityToken` has been called and resolved successfully.
+The token is a base64 encoded string.
 
 ```ts
 try {
@@ -140,6 +140,20 @@ try {
 }
 ```
 
+### `decodeAttestation`
+
+Decodes the CBOR encoded attestation returned by the `getAttestation` method. Returns an object containing `signature` and `authenticatorData` as base64 encoded strings.
+
+```ts
+try {
+  const decoded = await decodeAttestation(attestation);
+  console.log(decoded);
+} catch (e) {
+  const error = e as IntegrityError;
+  console.log(JSON.stringify(error));
+}
+```
+
 ## Types
 
 |      TypeName      | Description                                                                                                                       |
@@ -176,3 +190,7 @@ MIT
 ---
 
 Made with [create-react-native-library](https://github.com/callstack/react-native-builder-bob)
+
+```
+
+```

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -87,9 +87,11 @@ app.post(`/attest/verify`, (req, res) => {
  */
 app.post(`/assertion/verify`, (req, res) => {
   try {
-    const { hardwareKeyTag, assertion } = req.body;
+    const { hardwareKeyTag } = req.body;
 
-    if (hardwareKeyTag === undefined || assertion === undefined) {
+    console.log(req.body);
+
+    if (hardwareKeyTag === undefined) {
       throw new Error('Invalid authentication');
     }
 
@@ -102,7 +104,8 @@ app.post(`/assertion/verify`, (req, res) => {
     }
 
     const result = verifyAssertion({
-      assertion: Buffer.from(assertion, 'base64').toString('utf-8'),
+      signature: req.body.signature,
+      authenticatorData: req.body.authenticatorData,
       payload: req.body.payload,
       publicKey: attestation.publicKey,
       bundleIdentifier: BUNDLE_IDENTIFIER,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -89,8 +89,6 @@ app.post(`/assertion/verify`, (req, res) => {
   try {
     const { hardwareKeyTag } = req.body;
 
-    console.log(req.body);
-
     if (hardwareKeyTag === undefined) {
       throw new Error('Invalid authentication');
     }

--- a/backend/src/verifyAssertion.ts
+++ b/backend/src/verifyAssertion.ts
@@ -1,7 +1,8 @@
 import { createHash, createVerify } from 'crypto';
 
 export type VerifyAssertionParams = {
-  assertion: string;
+  signature: string;
+  authenticatorData: string;
   payload: Buffer;
   publicKey: string;
   bundleIdentifier: string;
@@ -16,7 +17,8 @@ export type VerifyAssertionParams = {
  */
 const verifyAssertion = (params: VerifyAssertionParams) => {
   const {
-    assertion,
+    signature,
+    authenticatorData,
     payload,
     publicKey,
     bundleIdentifier,
@@ -32,8 +34,12 @@ const verifyAssertion = (params: VerifyAssertionParams) => {
     throw new Error('teamIdentifier is required');
   }
 
-  if (!assertion) {
-    throw new Error('assertion is required');
+  if (!signature) {
+    throw new Error('signature is required');
+  }
+
+  if (!authenticatorData) {
+    throw new Error('authenticatorData is required');
   }
 
   if (!payload) {
@@ -44,11 +50,8 @@ const verifyAssertion = (params: VerifyAssertionParams) => {
     throw new Error('publicKey is required');
   }
 
-  // 1. Get signature and authenticator data from the assertion.
-  const { signature, authenticatorData } = JSON.parse(assertion);
-
-  const sign = Buffer.from(signature);
-  const authData = Buffer.from(authenticatorData);
+  const sign = Buffer.from(signature, 'base64');
+  const authData = Buffer.from(authenticatorData, 'base64');
   // 2. Compute the SHA256 hash of the client data, and store it as clientDataHash.
   const clientDataHash = createHash('sha256').update(payload).digest();
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
   - hermes-engine/Pre-built (0.73.6)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - pagopa-io-react-native-integrity (0.1.0):
+  - pagopa-io-react-native-integrity (0.2.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1338,7 +1338,7 @@ SPEC CHECKSUMS:
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  pagopa-io-react-native-integrity: 08fadabd6e676e1108a2e2ac0c633ba5cb67f150
+  pagopa-io-react-native-integrity: 70f8efc528e6855889233c8dd8d2c14ccb531089
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: ca1d7414aba0b27efcfa2ccd37637edb1ab77d96
   RCTTypeSafety: 678e344fb976ff98343ca61dc62e151f3a042292

--- a/example/src/IosApp.tsx
+++ b/example/src/IosApp.tsx
@@ -85,7 +85,7 @@ export default function App() {
         const nonce = await getChallengeFromServer();
         setChallenge(nonce);
         const res = await getAttestation(nonce, hardwareKeyTag);
-        setAssertion(res);
+        setAttestation(res);
         setDebugLog(res);
       }
     } catch (e) {

--- a/example/src/IosApp.tsx
+++ b/example/src/IosApp.tsx
@@ -111,7 +111,6 @@ export default function App() {
     if (assertion) {
       // decode CBOR assertion on native side (iOS only)
       const decodedAssertion = await decodeAssertion(assertion);
-      console.log(decodedAssertion);
       // verify attestation on the server with POST
       // and body of challenge, attestation and keyId
       const result = await postRequest('assertion/verify', {

--- a/example/src/IosApp.tsx
+++ b/example/src/IosApp.tsx
@@ -111,11 +111,13 @@ export default function App() {
     if (assertion) {
       // decode CBOR assertion on native side (iOS only)
       const decodedAssertion = await decodeAssertion(assertion);
+      console.log(decodedAssertion);
       // verify attestation on the server with POST
       // and body of challenge, attestation and keyId
       const result = await postRequest('assertion/verify', {
         challenge: challenge,
-        assertion: decodedAssertion,
+        signature: decodedAssertion.signature,
+        authenticatorData: decodedAssertion.authenticatorData,
         hardwareKeyTag: hardwareKeyTag,
         payload: JSON.stringify({ challenge: challenge, jwk: jwk }),
       });

--- a/ios/IoReactNativeIntegrity.swift
+++ b/ios/IoReactNativeIntegrity.swift
@@ -7,11 +7,6 @@ import SwiftCBOR
 class IoReactNativeIntegrity: NSObject {
   private typealias ME = ModuleException
   
-  struct DecodedData: Codable {
-    var signature: [UInt8]
-    var authenticatorData: [UInt8]
-  }
-  
   enum CBORDecodingError: Error {
     case invalidFormat(String)
   }
@@ -46,12 +41,13 @@ class IoReactNativeIntegrity: NSObject {
             case let .byteString(authenticatorDataBytes)? = map["authenticatorData"] else {
         throw CBORDecodingError.invalidFormat("Expected signature and authenticatorData in the CBOR map")
       }
-     
-      let decodedData = DecodedData(signature: signatureBytes, authenticatorData: authenticatorDataBytes)
       
-      let jsonData = try JSONEncoder().encode(decodedData)
+      let decodedData: [String:String]  = [
+        "signature": Data(signatureBytes).base64EncodedString(),
+        "authenticatorData": Data(authenticatorDataBytes).base64EncodedString()
+      ]
       
-      resolve(jsonData.base64EncodedString())
+      resolve(decodedData)
     } catch {
       ME.decodingAssertionFailed.reject(reject: reject, ("error", error.localizedDescription))
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ export type IntegrityError = {
 };
 
 /**
- * Tpye of the decoded attestation.
+ * Type of the decoded attestation.
  * Both signature and authenticatorData are base64 encoded.
  */
 export type DecodedAttestation = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,15 @@ export type IntegrityError = {
 };
 
 /**
+ * Tpye of the decoded attestation.
+ * Both signature and authenticatorData are base64 encoded.
+ */
+export type DecodedAttestation = {
+  signature: string;
+  authenticatorData: string;
+};
+
+/**
  * Error when the platform is not supported.
  */
 const IntegrityErrorUnsupportedError: IntegrityError = {
@@ -157,11 +166,11 @@ export function generateHardwareSignatureWithAssertion(
  * instance of {@link IntegrityError}.
  *
  * @param assertion - the CBOR assertion to be decoded
- * @returns - a promise that resolves to a string.
+ * @returns - a promise that resolves to a {@link DecodedAttestation} which contains base64 encoded signature and authenticatorData.
  */
 export function decodeAssertion(
   assertion: string
-): Promise<{ signature: string; authenticatorData: string }> {
+): Promise<DecodedAttestation> {
   return IoReactNativeIntegrity.decodeAssertion(assertion);
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -215,7 +215,7 @@ export function prepareIntegrityToken(
  * Integrity token request step for a [Play Integrity standard API request](https://developer.android.com/google/play/integrity/standard).
  * It requests an integrity token which is then attached to the request to be protected.
  * It should be called AFTER {@link prepareIntegrityToken} has been called and resolved successfully.
- * The React Native
+ * The token is a base64 encoded string.
  * @param requestHash a digest of all relevant request parameters (e.g. SHA256) from the user action or server request that is happening.
  * The max size of this field is 500 bytes. Do not put sensitive information as plain text in this field.
  * @returns a resolved promise with with the token as payload, rejected otherwise when:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -159,7 +159,9 @@ export function generateHardwareSignatureWithAssertion(
  * @param assertion - the CBOR assertion to be decoded
  * @returns - a promise that resolves to a string.
  */
-export function decodeAssertion(assertion: string): Promise<string> {
+export function decodeAssertion(
+  assertion: string
+): Promise<{ signature: string; authenticatorData: string }> {
   return IoReactNativeIntegrity.decodeAssertion(assertion);
 }
 


### PR DESCRIPTION
### Short description
This PR is a followup to #10 which changes the decoded assertion format to reflect what we expect in our actual backed which requires an `authenticatorData` and `signature` as base64 strings. Currently it returns the whole decoded assertion as a base64 string. This change reduces the complexity of the verification downstream.

#### List of Changes
- Changes the native method `decodeAssertion` implementation which now returns an object containing `authenticatorData` and `signature` as base64 encoded strings; 
- Updates the javascript part of the native bridge to reflect the aforementioned change with the proper return type;
- Updates the backend verification function to reflect the aforementioned change;
- Wraps the example app functions in `try-catch` to prevent unhandled rejected promises in case of error;
- Updates the documentation.

#### How Has This Been Tested?

- Set value in .env file under example app and backend
- Start metro with cd example && yarn start
- Start backend with cd backend && yarn start
- Using a supported iOS device open Xcode and start the example app
- Try sequentially every button
- Last CTA Verify Assertion should return a value like this {result: {signCount: 1}}
